### PR TITLE
Support reading cgroup v2 memory limit

### DIFF
--- a/assets/fedora-entrypoint.sh
+++ b/assets/fedora-entrypoint.sh
@@ -4,13 +4,15 @@ echo "Changing ownership of /data as $(whoami)"
 chown jetty:jetty /data
 echo "Downgrading privileges and resuming"
 
-for MEM_FILE in memory.limit_in_bytes memory.memsw.limit_in_bytes memory.kmem.limit_in_bytes; do
-  if [[ -e /sys/fs/cgroup/memory/${MEM_FILE} ]]; then
+for MEM_FILE in memory.max memory/memory.limit_in_bytes memory/memory.memsw.limit_in_bytes memory/memory.kmem.limit_in_bytes; do
+  echo "Checking for /sys/fs/cgroup/$MEM_FILE..."
+  if [[ -e /sys/fs/cgroup/${MEM_FILE} ]]; then
+    echo "Found."
     break
   fi
 done
 
-if [[ ! -e /sys/fs/cgroup/memory/${MEM_FILE} ]]; then
+if [[ ! -e /sys/fs/cgroup/${MEM_FILE} ]]; then
   echo "Could not read container memory. Exiting."
   exit 1
 fi
@@ -21,8 +23,8 @@ if [[ -d /jetty-overrides ]]; then
   cd -
 fi
 
-MEM_BYTES=$(cat /sys/fs/cgroup/memory/${MEM_FILE})
-if [[ $MEM_BYTES -ne "9223372036854771712" ]]; then
+MEM_BYTES=$(cat /sys/fs/cgroup/${MEM_FILE})
+if [[ $MEM_BYTES -ne "max" && $MEM_BYTES -ne "9223372036854771712" ]]; then
   let "MX=$MEM_BYTES * 8 / 10 / 1024 / 1024"
   echo "Setting -Xmx${MX}m"
   JAVA_OPTIONS="${JAVA_OPTIONS} -Xmx${MX}m"


### PR DESCRIPTION
cgroup v2 has a different interface for exposing memory limits which prevented use of this image.

This adds:

- Support for reading the memory limit set by the -m docker run option from `/sys/fs/cgroup/memory.max` which has a default value of "max".
- Outputs which file it is attempting to read from.